### PR TITLE
channelled Logger

### DIFF
--- a/logging/src/main/java/net/daporkchop/lib/logging/impl/SimpleLogger.java
+++ b/logging/src/main/java/net/daporkchop/lib/logging/impl/SimpleLogger.java
@@ -231,7 +231,7 @@ public class SimpleLogger implements Logger {
 
         @Override
         public Logger channel(@NonNull String name) {
-            return SimpleLogger.this.channel(name);
+            return SimpleLogger.this.channel(this.name + "/" + name);
         }
     }
 }


### PR DESCRIPTION
when you make a channel of a channel it will just keep the name you have given to it without any indication that it was a channel of a channel. This Pull request appends the original name of the channel so it is visible in the log what kind of channel the message came from