### PR TITLE
Fix loading of worlds other than the overworld

### DIFF
--- a/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
+++ b/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
@@ -104,7 +104,7 @@ public class AnvilSaveFormat implements SaveFormat {
                 matcher.reset(file.getName());
             }
             if (matcher.find()) {
-                callback.accept(Integer.parseInt(matcher.group(1)), new AnvilWorldManager(this, file));
+                callback.accept(Integer.parseInt(matcher.group(1)), new AnvilWorldManager(this, new File(file, "region")));
             }
         }
     }


### PR DESCRIPTION
MinecraftSave.world() for ids other than 0 has never worked as the regions are stored 1 folder deeper, in the region directory in every dimension.
this fixes that