### PR TITLE
Fixes in order to restore SaveSearcher temporarily while waiting for rewrite

### DIFF
--- a/minecraft/src/main/java/net/daporkchop/lib/minecraft/registry/ResourceLocation.java
+++ b/minecraft/src/main/java/net/daporkchop/lib/minecraft/registry/ResourceLocation.java
@@ -37,7 +37,7 @@ import java.util.regex.Pattern;
  */
 @Getter
 public final class ResourceLocation {
-    protected static final Pattern      VALIDATION_PATTERN = Pattern.compile("^([^:]+):([^:]+)$");
+    protected static final Pattern      VALIDATION_PATTERN = Pattern.compile("^(.+):(.+)$");
     protected static final Ref<Matcher> MATCHER_CACHE      = ThreadRef.soft(() -> VALIDATION_PATTERN.matcher(""));
 
     @NonNull

--- a/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
+++ b/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
@@ -35,9 +35,7 @@ import net.daporkchop.lib.nbt.tag.notch.CompoundTag;
 import net.daporkchop.lib.nbt.tag.notch.ListTag;
 import net.daporkchop.lib.primitive.lambda.consumer.IntObjConsumer;
 
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
+import java.io.*;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -104,7 +102,7 @@ public class AnvilSaveFormat implements SaveFormat {
                 matcher.reset(file.getName());
             }
             if (matcher.find()) {
-                callback.accept(Integer.parseInt(matcher.group(1)), new AnvilWorldManager(this, file));
+                callback.accept(Integer.parseInt(matcher.group(1)), new AnvilWorldManager(this, new File(file, "region")));
             }
         }
     }

--- a/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
+++ b/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
@@ -95,7 +95,14 @@ public class AnvilSaveFormat implements SaveFormat {
 
         //load other dimensions
         Matcher matcher = null;
-        for (File file : this.root.listFiles()) {
+        //Find all subfolders
+        File[] directories = this.root.listFiles(new FileFilter() {
+            @Override
+            public boolean accept(File file) {
+                return file.isDirectory();
+            }
+        });
+        for (File file : directories) {
             if (matcher == null)    {
                 matcher = DIM_PATTERN.matcher(file.getName());
             } else {

--- a/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
+++ b/minecraft/src/main/java/net/daporkchop/lib/minecraft/world/format/anvil/AnvilSaveFormat.java
@@ -36,9 +36,17 @@ import net.daporkchop.lib.nbt.tag.notch.ListTag;
 import net.daporkchop.lib.primitive.lambda.consumer.IntObjConsumer;
 
 import java.io.*;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import java.util.zip.GZIPInputStream;
 
 /**
@@ -96,12 +104,14 @@ public class AnvilSaveFormat implements SaveFormat {
         //load other dimensions
         Matcher matcher = null;
         //Find all subfolders
-        File[] directories = this.root.listFiles(new FileFilter() {
-            @Override
-            public boolean accept(File file) {
-                return file.isDirectory();
-            }
-        });
+        List<File> directories = new ArrayList<>();
+        try (Stream<Path> paths = Files.walk(this.root.toPath())){
+            directories = paths
+                    .filter(Files::isDirectory)
+                    .map(Path::toFile)
+                    .collect(Collectors.toList());
+        } catch (IOException e) {}
+
         for (File file : directories) {
             if (matcher == null)    {
                 matcher = DIM_PATTERN.matcher(file.getName());
@@ -112,6 +122,7 @@ public class AnvilSaveFormat implements SaveFormat {
                 callback.accept(Integer.parseInt(matcher.group(1)), new AnvilWorldManager(this, new File(file, "region")));
             }
         }
+
     }
 
     @Override


### PR DESCRIPTION
This PR addresses some issues that prevent SaveSearcher from properly working. While i know that SaveSearcher is on hold while waiting for the WorldLib rewrite, this PR enables usage for regular users in the meantime. Changes:

- Use "region" folder instead of the root folder to load a dimension
- Look for dimensions folders in any subdirectory (needed for cases such as Advanced Rocketry that use their own custom folder)
- Relax registry regex matcher in order to allow the existance of mod entries with multiple colons in their id (such as Common Capabilities)